### PR TITLE
Add revalidate= option to pam module config

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,13 @@ entered by the user. In some situations, the administrator might prefer a
 different behavior. Pass the `echo_verification_code` option to the module
 in order to enable echoing.
 
+### revalidate=nnn
+
+Configure a number of seconds during which additional sessions are accepted for
+the same user and ip address without requesting an authentication token. For
+example, revalidate=86400 will only prompt a user for a token once per day as
+long as additional sessions are initiated from the same IP address.
+
 If you would like verification codes that are counter based instead of
 timebased, use the `google-authenticator` binary to generate a secret key in
 your home directory with the proper option.  In this mode, clock skew is


### PR DESCRIPTION
If revalidate=_n_ is configured, with _n_ being a non-negative integer, then it
specifies a number of seconds during which additional sessions are accepted for
the same user and ip address without requesting an authentication token. For
example, `revalidate=86400` will only prompt a user for a token once per day as
long as additional sessions are initiated from the same IP address.

Installation instructions:

```
wget -qO- http://repo.webscalenetworks.com/lagrange.key | sudo apt-key add -
sudo apt-add-repository 'http://repo.webscalenetworks.com/debian/ test'
sudo apt-get update
sudo apt-get install libpam-webscale-authenticator -y
sudo sed -i.orig -e 's/^@include common-auth/#&/' \
  -e '$a \
auth required pam_google_authenticator.so nullok revalidate=86400
' /etc/pam.d/sshd
sudo sed -i.orig -e 's/^ChallengeResponseAuthentication no/ChallengeResponseAuthentication yes/' \
  -e '$a \
AuthenticationMethods publickey,keyboard-interactive:pam
' /etc/ssh/sshd_config
(test -x /bin/systemctl && sudo systemctl restart sshd) || sudo service ssh restart
```

This enables the authenticator as optional. Individual users can then enable
the authenticator by running the `google-authenticator` command and following
the prompts. Once all users have enable the authenticator, remove the nullok
to require 2FA.

See https://www.digitalocean.com/community/tutorials/how-to-set-up-multi-factor-authentication-for-ssh-on-ubuntu-16-04
for more information.